### PR TITLE
Add multi-select document deletion

### DIFF
--- a/src/lib/Modal.svelte
+++ b/src/lib/Modal.svelte
@@ -11,26 +11,38 @@
   return value;
  }
 
- function parseValue(value) {
-  if (value === "true") return true;
-  if (value === "false") return false;
-  if (value === "null") return null;
-  if (!isNaN(parseInt(value))) {
-   if (value.includes(".")) {
-    return parseFloat(value);
-   }
-   return parseInt(value);
-  }
-  if (value.startsWith('"') && value.endsWith('"')) {
-   return value.slice(1, -1);
-  }
+function parseLooseJSON(value) {
+ try {
+  return JSON.parse(value);
+ } catch {
   try {
-   return JSON.parse(value);
-  } catch (err) {
-   alert("Error when parsing JSON: " + err)
-   return value;
+   return JSON.parse(value.replace(/([,{]\s*)([a-zA-Z0-9_]+)\s*:/g, '$1"$2":'));
+  } catch {
+   try {
+    return new Function('return (' + value + ')')();
+   } catch (err) {
+    alert('Error when parsing JSON: ' + err);
+    return value;
+   }
   }
  }
+}
+
+function parseValue(value) {
+ if (value === "true") return true;
+ if (value === "false") return false;
+ if (value === "null") return null;
+ if (!isNaN(parseInt(value))) {
+  if (value.includes(".")) {
+   return parseFloat(value);
+  }
+  return parseInt(value);
+ }
+ if (value.startsWith('"') && value.endsWith('"')) {
+  return value.slice(1, -1);
+ }
+ return parseLooseJSON(value);
+}
 
  function handleCancel() {
   closeModal(0);
@@ -56,7 +68,7 @@
 
 {#if $modalData}
  <div class="modal">
-  <div class="title">Edit value</div>
+  <div class="title">{$modalData.title || 'Edit value'}</div>
   <textarea value={stringifyValue($modalData.value)} oninput={(e) => newValue = e.target.value}></textarea>
   <div class="actions">
    <button class="default cancel" onclick={handleCancel}>Cancel</button>

--- a/src/routes/(app)/CurrentCollection.svelte
+++ b/src/routes/(app)/CurrentCollection.svelte
@@ -1,13 +1,19 @@
 <script>
- import { sidebarWidth, databases, openCollections, selectedOpenCollectionId, queryRunning } from "$lib/stores";
- import DocumentKeyRepresentation from "./DocumentKeyRepresentation.svelte";
- import CollectionTabs from "./CollectionTabs.svelte";
- import { onMount } from "svelte";
+import { sidebarWidth, databases, openCollections, selectedOpenCollectionId, queryRunning } from "$lib/stores";
+import DocumentKeyRepresentation from "./DocumentKeyRepresentation.svelte";
+import CollectionTabs from "./CollectionTabs.svelte";
+import { onMount } from "svelte";
+import { openModal, modalData } from "$lib/modal.js";
 
  let { collection, tabsElemHeight } = $props();
 
- let expandedDocumentIndexes = $state([]);
- let noResults = $state(false);
+let expandedDocumentIndexes = $state([]);
+let selectedDocumentIndexes = $state([]);
+let lastSelectedIndex = $state(null);
+let noResults = $state(false);
+let totalDocuments = $state(0);
+
+onMount(fetchTotalCount);
 
  $effect(() => {
   if ($selectedOpenCollectionId === collection.id) {
@@ -57,7 +63,7 @@
   writeKeyToLocalStorage("limit", parseInt(limit));
  }
 
- function writeKeyToLocalStorage(key, value) {
+function writeKeyToLocalStorage(key, value) {
   let before = JSON.parse(localStorage.getItem(`${collection.database}.${collection.collection}`) || "{}");
   localStorage.setItem(`${collection.database}.${collection.collection}`, JSON.stringify({
    ...before,
@@ -66,9 +72,11 @@
  }
 
  async function runQuery() {
-  if ($queryRunning) return;
-  $queryRunning = true;
-  expandedDocumentIndexes = [];
+ if ($queryRunning) return;
+ $queryRunning = true;
+ expandedDocumentIndexes = [];
+ selectedDocumentIndexes = [];
+ lastSelectedIndex = null;
   let currentCollection = $openCollections.find(col => col.id === $selectedOpenCollectionId);
   try {
    let response = await fetch(`/api/v1/databases/${currentCollection.database}/run-query`, {
@@ -78,8 +86,8 @@
     },
     body: JSON.stringify({
      collection: currentCollection.collection,
-     query: JSON.parse(currentCollection.query.replace(/([{,]\s*)([a-zA-Z0-9_]+)\s*:/g, '$1"$2":')),
-     projection: JSON.parse(currentCollection.projection.replace(/([{,]\s*)([a-zA-Z0-9_]+)\s*:/g, '$1"$2":')),
+     query: parseLooseJSON(currentCollection.query),
+     projection: parseLooseJSON(currentCollection.projection),
      limit: currentCollection.limit,
     }),
    });
@@ -95,6 +103,7 @@
      }
      return col;
     });
+    await fetchTotalCount();
     $queryRunning = false;
    } else {
     let err = await response.text();
@@ -107,9 +116,174 @@
   }
  }
 
- function handleExpandDocument(index, key) {
-  expandedDocumentIndexes = expandedDocumentIndexes.includes(index) ? expandedDocumentIndexes.filter(i => i !== index) : [...expandedDocumentIndexes, index];
+function handleExpandDocument(index, key) {
+ expandedDocumentIndexes = expandedDocumentIndexes.includes(index) ? expandedDocumentIndexes.filter(i => i !== index) : [...expandedDocumentIndexes, index];
+}
+
+function parseLooseJSON(str) {
+ try {
+  return JSON.parse(str);
+ } catch {
+  try {
+   return JSON.parse(str.replace(/([,{]\s*)([a-zA-Z0-9_]+)\s*:/g, '$1"$2":'));
+  } catch {
+   return new Function('return (' + str + ')')();
+  }
  }
+}
+
+async function fetchTotalCount() {
+ let currentCollection = $openCollections.find(col => col.id === $selectedOpenCollectionId);
+ if (!currentCollection) return;
+ try {
+  let res = await fetch(`/api/v1/databases/${currentCollection.database}/run-count`, {
+   method: 'POST',
+   headers: { 'Content-Type': 'application/json' },
+   body: JSON.stringify({ collection: currentCollection.collection })
+  });
+  if (res.ok) {
+   let data = await res.json();
+   totalDocuments = data.total;
+  }
+ } catch {}
+}
+
+function handleDocumentClick(event, index) {
+ if (event.detail === 2) {
+  openEditItemModal(index);
+  return;
+ }
+ if (event.ctrlKey || event.metaKey) {
+  if (selectedDocumentIndexes.includes(index)) {
+   selectedDocumentIndexes = selectedDocumentIndexes.filter(i => i !== index);
+  } else {
+   selectedDocumentIndexes = [...selectedDocumentIndexes, index];
+  }
+  lastSelectedIndex = index;
+ } else if (event.shiftKey && lastSelectedIndex !== null) {
+  let start = Math.min(lastSelectedIndex, index);
+  let end = Math.max(lastSelectedIndex, index);
+  let range = [];
+  for (let i = start; i <= end; i++) range.push(i);
+  selectedDocumentIndexes = Array.from(new Set([...selectedDocumentIndexes, ...range]));
+ } else {
+  if (selectedDocumentIndexes.length === 1 && selectedDocumentIndexes[0] === index) {
+   selectedDocumentIndexes = [];
+   lastSelectedIndex = null;
+  } else {
+   selectedDocumentIndexes = [index];
+   lastSelectedIndex = index;
+  }
+ }
+}
+
+async function deleteSelected() {
+ if (!selectedDocumentIndexes.length) return;
+ if (!confirm(`Delete ${selectedDocumentIndexes.length} document(s)?`)) return;
+ let currentCollection = $openCollections.find(col => col.id === $selectedOpenCollectionId);
+ try {
+  let response = await fetch(`/api/v1/databases/${currentCollection.database}/run-delete-many`, {
+   method: "DELETE",
+   headers: {
+    "Content-Type": "application/json",
+   },
+   body: JSON.stringify({
+    collection: currentCollection.collection,
+    ids: selectedDocumentIndexes.map(i => currentCollection.documents[i]._id),
+   }),
+  });
+  if (response.ok) {
+   $openCollections = $openCollections.map(col => {
+    if (col.id === $selectedOpenCollectionId) {
+     return {
+      ...col,
+      documents: col.documents.filter((_, idx) => !selectedDocumentIndexes.includes(idx)),
+     };
+    }
+    return col;
+   });
+   expandedDocumentIndexes = expandedDocumentIndexes.filter(i => !selectedDocumentIndexes.includes(i));
+   selectedDocumentIndexes = [];
+   lastSelectedIndex = null;
+  } else {
+   let err = await response.text();
+   alert(`Failed to delete documents: ${err}`);
+  }
+ } catch (err) {
+  alert(`Failed to delete documents: ${err}`);
+ }
+}
+
+function openAddItemModal() {
+ openModal({ title: 'Add item', value: {} }, async (code) => {
+  if (code === 0) return true;
+  let currentCollection = $openCollections.find(col => col.id === $selectedOpenCollectionId);
+  try {
+   let response = await fetch(`/api/v1/databases/${currentCollection.database}/run-insert-one`, {
+    method: 'POST',
+    headers: {
+     'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+     collection: currentCollection.collection,
+     document: $modalData.value,
+    }),
+   });
+   if (response.ok) {
+    let result = await response.json();
+    $openCollections = $openCollections.map(col => {
+     if (col.id === $selectedOpenCollectionId) {
+      return { ...col, documents: [{ _id: result.insertedId, ...$modalData.value }, ...col.documents] };
+     }
+     return col;
+    });
+    return true;
+   } else {
+    let err = await response.text();
+    alert(`Failed to insert document: ${err}`);
+    return false;
+   }
+  } catch (err) {
+   alert(`Failed to insert document: ${err}`);
+   return false;
+  }
+ });
+}
+
+function openEditItemModal(index) {
+ let doc = collection.documents[index];
+ openModal({ title: 'Edit item', value: { ...doc } }, async (code) => {
+  if (code === 0) return true;
+  let currentCollection = $openCollections.find(col => col.id === $selectedOpenCollectionId);
+  try {
+   let response = await fetch(`/api/v1/databases/${currentCollection.database}/run-update-one`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+     collection: currentCollection.collection,
+     _id: doc._id,
+     query: { $set: $modalData.value }
+    })
+   });
+   if (response.ok) {
+    $openCollections = $openCollections.map(col => {
+     if (col.id === $selectedOpenCollectionId) {
+      return { ...col, documents: col.documents.map((d,i) => i===index ? { _id: doc._id, ...$modalData.value } : d) };
+     }
+     return col;
+    });
+    return true;
+   } else {
+    let err = await response.text();
+    alert(`Failed to update document: ${err}`);
+    return false;
+   }
+  } catch (err) {
+   alert(`Failed to update document: ${err}`);
+   return false;
+  }
+ });
+}
 </script>
 
 <div class="collection-container" style="--tabs-elem-height: {tabsElemHeight}px;">
@@ -125,10 +299,11 @@
  <div class="divider"></div>
  <div class="input-wrapper">
   <div class="label">Limit</div>
-  <input type="number" class="input" value={collection.limit} oninput={(e) => handleNewLimit(e.target.value)} />
- </div>
- <div class="divider"></div>
- <div class="actions-wrapper">
+ <input type="number" class="input" value={collection.limit} oninput={(e) => handleNewLimit(e.target.value)} />
+</div>
+<div class="divider"></div>
+ <div class="count">{collection.documents.length} / {totalDocuments}</div>
+<div class="actions-wrapper">
   <button class="run-query default" onclick={runQuery}>
    {#if $queryRunning}
     • • •
@@ -137,14 +312,22 @@
     Run query
    {/if}
   </button>
- </div>
+  <button class="add default" onclick={openAddItemModal}>
+   <img src="/assets/icons/plus.svg" alt="add" class="icon" />
+   Add item
+  </button>
+  <button class="delete default" onclick={deleteSelected} disabled={selectedDocumentIndexes.length === 0}>
+   <img src="/assets/icons/trash.svg" alt="delete" class="icon" />
+   Delete selected
+  </button>
+</div>
  {#if !$queryRunning}
   <div class="documents">
    {#each collection.documents as document, i}
     {@const isOpen = expandedDocumentIndexes.includes(i)}
-    <div class="document">
+    <div class="document {selectedDocumentIndexes.includes(i) ? 'selected' : ''}" onclick={(e) => handleDocumentClick(e, i)}>
      <div class="header">
-      <button class="expand {isOpen ? "open" : ""}" onclick={() => handleExpandDocument(i)}>
+      <button class="expand {isOpen ? 'open' : ''}" onclick={(e) => { e.stopPropagation(); handleExpandDocument(i); }}>
        <img src="/assets/icons/play.svg" alt="expand" class="expand">
       </button>
       <div class="title">[{i}] | {document._id}</div>
@@ -174,12 +357,17 @@
   height: calc(100% - var(--tabs-elem-height) - 5px);
  }
 
- div.collection-container div.divider {
-  width: 100%;
-  height: 1px;
-  background: #fff;
-  opacity: .15;
- }
+div.collection-container div.divider {
+ width: 100%;
+ height: 1px;
+ background: #fff;
+ opacity: .15;
+}
+
+div.collection-container div.count {
+ font-size: .8em;
+ opacity: .8;
+}
 
  div.collection-container div.input-wrapper {
   display: flex;
@@ -223,9 +411,49 @@
   padding: .5em .8em;
  }
 
- div.collection-container button.run-query img.icon {
-  width: .8em;
- }
+div.collection-container button.run-query img.icon {
+ width: .8em;
+}
+
+div.collection-container button.add {
+ display: flex;
+ align-items: center;
+ gap: .8em;
+ width: max-content;
+ font-size: .8em;
+ font-weight: 500;
+ padding: .5em .8em;
+ background: rgba(50, 200, 50, .4);
+}
+
+div.collection-container button.add img.icon {
+ width: .8em;
+}
+
+div.collection-container div.actions-wrapper {
+ display: flex;
+ align-items: center;
+ gap: 1em;
+}
+
+div.collection-container button.delete {
+ display: flex;
+ align-items: center;
+ gap: .8em;
+ width: max-content;
+ font-size: .8em;
+ font-weight: 500;
+ padding: .5em .8em;
+ background: rgba(255, 50, 50, .4);
+}
+
+div.collection-container button.delete img.icon {
+ width: .8em;
+}
+
+div.collection-container div.document.selected {
+ background: rgba(255, 255, 255, .12);
+}
 
  div.collection-container div.documents {
   display: flex;

--- a/src/routes/api/v1/databases/[databaseName]/run-count/+server.js
+++ b/src/routes/api/v1/databases/[databaseName]/run-count/+server.js
@@ -1,0 +1,23 @@
+import { error, json } from "@sveltejs/kit";
+import * as env from "$env/static/private";
+import { connect } from "$lib/server/db/mongo.js";
+import { getUserDBConfig, getUserCollectionAccess } from "$lib/server/utils";
+
+let databases = JSON.parse(env.DATABASES || "[]");
+
+export async function POST(event) {
+  if (!event.locals.user) return error(401, "Unauthorized");
+  const databaseName = event.params.databaseName;
+  const userDBConfig = getUserDBConfig(event.locals.user.username, databaseName);
+  if (!userDBConfig) return error(401, "Unauthorized");
+  const { collection } = await event.request.json();
+  const hasAccess = getUserCollectionAccess(userDBConfig, collection);
+  if (!hasAccess) return error(401, "Unauthorized");
+  const db = await connect(databases.findIndex(db => db.db === databaseName));
+  try {
+    const total = await db.connection.collection(collection).countDocuments();
+    return json({ total });
+  } catch (err) {
+    return error(500, err.message);
+  }
+}

--- a/src/routes/api/v1/databases/[databaseName]/run-delete-many/+server.js
+++ b/src/routes/api/v1/databases/[databaseName]/run-delete-many/+server.js
@@ -1,0 +1,38 @@
+import { error, json } from "@sveltejs/kit";
+import * as env from "$env/static/private";
+import { connect } from "$lib/server/db/mongo.js";
+import { getUserDBConfig, getUserCollectionAccess, consumeLimit, handleWebhookMessages } from "$lib/server/utils";
+
+let users = JSON.parse(env.USERS || "[]");
+let databases = JSON.parse(env.DATABASES || "[]");
+
+export async function DELETE(event) {
+ if (!event.locals.user) return error(401, "Unauthorized");
+ let databaseName = event.params.databaseName;
+ let userDBConfig = getUserDBConfig(event.locals.user.username, databaseName);
+ if (!userDBConfig?.write) return error(401, "Unauthorized");
+ let { collection, ids } = await event.request.json();
+ let hasCollectionAccess = getUserCollectionAccess(userDBConfig, collection);
+ if (!hasCollectionAccess) return error(401, "Unauthorized");
+ let ok = consumeLimit({
+  type: "write",
+  username: event.locals.user.username,
+  databaseName,
+  count: ids.length,
+ });
+ if (!ok) return error(429, "This request exceeds your daily limit");
+ let db = await connect(databases.findIndex(db => db.db === databaseName));
+ try {
+  let result = await db.connection.collection(collection).deleteMany({ _id: { $in: ids } });
+  handleWebhookMessages({
+   type: "write",
+   username: event.locals.user.username,
+   databaseName,
+   collection,
+   query: { _id: { $in: ids } }
+  });
+  return json(result);
+ } catch (err) {
+  return error(500, err.message);
+ }
+}

--- a/src/routes/api/v1/databases/[databaseName]/run-insert-one/+server.js
+++ b/src/routes/api/v1/databases/[databaseName]/run-insert-one/+server.js
@@ -1,0 +1,38 @@
+import { error, json } from "@sveltejs/kit";
+import * as env from "$env/static/private";
+import { connect } from "$lib/server/db/mongo.js";
+import { getUserDBConfig, getUserCollectionAccess, consumeLimit, handleWebhookMessages } from "$lib/server/utils";
+
+let users = JSON.parse(env.USERS || "[]");
+let databases = JSON.parse(env.DATABASES || "[]");
+
+export async function POST(event) {
+  if (!event.locals.user) return error(401, "Unauthorized");
+  let databaseName = event.params.databaseName;
+  let userDBConfig = getUserDBConfig(event.locals.user.username, databaseName);
+  if (!userDBConfig?.write) return error(401, "Unauthorized");
+  let { collection, document } = await event.request.json();
+  let hasCollectionAccess = getUserCollectionAccess(userDBConfig, collection);
+  if (!hasCollectionAccess) return error(401, "Unauthorized");
+  let ok = consumeLimit({
+    type: "write",
+    username: event.locals.user.username,
+    databaseName,
+    count: 1,
+  });
+  if (!ok) return error(429, "This request exceeds your daily limit");
+  let db = await connect(databases.findIndex(db => db.db === databaseName));
+  try {
+    let result = await db.connection.collection(collection).insertOne(document);
+    handleWebhookMessages({
+      type: "write",
+      username: event.locals.user.username,
+      databaseName,
+      collection,
+      query: document,
+    });
+    return json(result);
+  } catch (err) {
+    return error(500, err.message);
+  }
+}

--- a/static/assets/icons/plus.svg
+++ b/static/assets/icons/plus.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M12 5v14M5 12h14" stroke="#ffffff" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/static/assets/icons/trash.svg
+++ b/static/assets/icons/trash.svg
@@ -1,0 +1,10 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g id="SVGRepo_bgCarrier" stroke-width="0"></g>
+  <g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g>
+  <g id="SVGRepo_iconCarrier">
+    <path d="M3 6h18" stroke="#ffffff" stroke-width="2" stroke-linecap="round"/>
+    <path d="M8 6V4h8v2" stroke="#ffffff" stroke-width="2" stroke-linecap="round"/>
+    <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M10 11v6M14 11v6" stroke="#ffffff" stroke-width="2" stroke-linecap="round"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- allow selecting documents via single-click and toggle open on double-click
- add bulk delete button and styles
- support deleteMany on the backend via new endpoint
- tweak UI based on feedback: subtle selection color, aligned delete button with bin icon
- unselect documents on second click, plus add-item modal and insert endpoint
- edit documents via modal on double-click and display result/total counts
- loose JSON parsing in the modal
- add run-count endpoint to fetch collection totals

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68442f24bdac83298cfee73d00872943